### PR TITLE
tag as incomplete type

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ A minimal example:
 using namespace igor;
 
 // Create a named argument called "arg1".
-struct arg1_tag {};
-inline constexpr auto arg1 = named_argument<arg1_tag>{};
+inline constexpr auto arg1 = named_argument<struct arg1_tag>{};
 
-// You can also use a macro (ew, gross!) for brevity.
+// You can also use a macro (ew, gross!).
 IGOR_MAKE_NAMED_ARGUMENT(arg2);
 
 // A variadic function accepting named arguments.

--- a/include/igor/igor.hpp
+++ b/include/igor/igor.hpp
@@ -281,8 +281,6 @@ private:
 
 // Handy macro (ew) for the definition of a named argument.
 #define IGOR_MAKE_NAMED_ARGUMENT(name)                                                                                 \
-    struct name##_tag {                                                                                                \
-    };                                                                                                                 \
-    inline constexpr auto name = ::igor::named_argument<name##_tag> {}
+    inline constexpr auto name = ::igor::named_argument<struct name##_tag> {}
 
 #endif


### PR DESCRIPTION
The library not necessary requires that the `_tag` class need to be defined.
This makes the not macro variant named argument declaration simple too.