### PR TITLE
add constexpr to all function

### DIFF
--- a/include/igor/igor.hpp
+++ b/include/igor/igor.hpp
@@ -53,29 +53,29 @@ template <typename Tag>
 struct named_argument {
     // NOTE: make sure this does not interfere with the copy/move assignment operators.
     template <typename T, ::std::enable_if_t<!::std::is_same_v<named_argument, detail::uncvref_t<T>>, int> = 0>
-    auto operator=(T &&x) const
+    constexpr auto operator=(T &&x) const
     {
         return detail::tagged_container<Tag, T &&>{::std::forward<T>(x)};
     }
 
     // Add overloads for std::initializer_list as well.
     template <typename T>
-    auto operator=(const ::std::initializer_list<T> &l) const
+    constexpr auto operator=(const ::std::initializer_list<T> &l) const
     {
         return detail::tagged_container<Tag, const ::std::initializer_list<T> &>{l};
     }
     template <typename T>
-    auto operator=(::std::initializer_list<T> &l) const
+    constexpr auto operator=(::std::initializer_list<T> &l) const
     {
         return detail::tagged_container<Tag, ::std::initializer_list<T> &>{l};
     }
     template <typename T>
-    auto operator=(::std::initializer_list<T> &&l) const
+    constexpr auto operator=(::std::initializer_list<T> &&l) const
     {
         return detail::tagged_container<Tag, ::std::initializer_list<T> &&>{::std::move(l)};
     }
     template <typename T>
-    auto operator=(const ::std::initializer_list<T> &&l) const
+    constexpr auto operator=(const ::std::initializer_list<T> &&l) const
     {
         return detail::tagged_container<Tag, const ::std::initializer_list<T> &&>{::std::move(l)};
     }
@@ -117,7 +117,7 @@ struct is_tagged_container_any<tagged_container<Tag, T>> : ::std::true_type {
 // (as const ref) and will filter out the named arguments
 // (which are returned as a tuple of const references).
 template <typename... Args>
-inline auto build_parser_tuple(const Args &... args)
+constexpr inline auto build_parser_tuple(const Args &... args)
 {
     [[maybe_unused]] auto filter_na = [](const auto &x) {
         if constexpr (is_tagged_container_any<uncvref_t<decltype(x)>>::value) {
@@ -201,14 +201,14 @@ class parser
     using tuple_t = decltype(detail::build_parser_tuple(::std::declval<const ParseArgs &>()...));
 
 public:
-    explicit parser(const ParseArgs &... parse_args) : m_nargs(detail::build_parser_tuple(parse_args...)) {}
+    constexpr explicit parser(const ParseArgs &... parse_args) : m_nargs(detail::build_parser_tuple(parse_args...)) {}
 
 private:
     // Fetch the value associated to the input named
     // argument narg. If narg is not present, this will
     // return a const ref to a global not_provided_t object.
     template <::std::size_t I, typename Tag>
-    decltype(auto) fetch_one_impl([[maybe_unused]] const named_argument<Tag> &narg) const
+    constexpr decltype(auto) fetch_one_impl([[maybe_unused]] const named_argument<Tag> &narg) const
     {
         if constexpr (I == ::std::tuple_size_v<tuple_t>) {
             return static_cast<const not_provided_t &>(not_provided);
@@ -227,7 +227,7 @@ private:
 public:
     // Get references to the values associated to the input named arguments.
     template <typename... Tags>
-    decltype(auto) operator()([[maybe_unused]] const named_argument<Tags> &... nargs) const
+    constexpr decltype(auto) operator()([[maybe_unused]] const named_argument<Tags> &... nargs) const
     {
         if constexpr (sizeof...(Tags) == 0u) {
             return;

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -288,3 +288,25 @@ TEST_CASE("test_has_duplicates")
     REQUIRE(has_duplicates_test(arg1 = 4, arg2 = 56, arg2 = 5, arg1 = 6, arg3 = 5.6));
     REQUIRE(has_duplicates_test(arg3 = "Hello", arg1 = 4, arg2 = 56, arg2 = 5, arg1 = 6));
 }
+
+template<typename... Args>
+inline constexpr auto sum(Args &&... args)
+{
+    parser p{args...};
+    
+    if constexpr(!p.has_all(arg1, arg2, arg3))
+        return -1;
+    else {
+        auto [a1, a2, a3] = p(arg1, arg2, arg3);
+        return a1 + a2 * a3;
+    }
+}
+
+TEST_CASE("constexprness")
+{
+    constexpr auto resultOfSum = sum(arg2 = 8, arg1 = 0.5, arg3 = 7);
+    constexpr auto notEnoughArgs = sum(arg3 = 4, arg1 = 6);
+
+    REQUIRE(resultOfSum == 56.5);
+    REQUIRE(notEnoughArgs == -1);
+}


### PR DESCRIPTION
After this, the named parameters can be used in constexpr evaluated context